### PR TITLE
Set info that MODX runs in connector mode

### DIFF
--- a/assets/components/pdotools/connector.php
+++ b/assets/components/pdotools/connector.php
@@ -7,6 +7,7 @@ $modx->initialize('web');
 $modx->getService('error','error.modError', '', '');
 $modx->setLogLevel(modX::LOG_LEVEL_ERROR);
 $modx->setLogTarget('FILE');
+define('MODX_CONNECTOR_INCLUDED', 1);
 
 // Switch context if needed
 if (!empty($_REQUEST['pageId'])) {


### PR DESCRIPTION
See the discussion on https://community.modx.com/t/pdopage-ajax-pagination-not-working-on-multilanguage-website/7244/3

Routing plugins (LangRouter, SmartRouting or xRouting) have to know that MODX runs in connector mode to disable running in onHandleRequest.

See i.e. https://github.com/Jako/LangRouter/blob/master/core/components/langrouter/src/Plugins/Events/OnHandleRequest.php#L21-L26
https://github.com/Jako/SmartRouting/blob/master/core/components/smartrouting/src/Plugins/Events/OnHandleRequest.php#L22-L27
